### PR TITLE
Normalize env vars, update default Gemini model

### DIFF
--- a/scripts/daily_quiz/generate_quiz.py
+++ b/scripts/daily_quiz/generate_quiz.py
@@ -28,12 +28,13 @@ WORKBOOKS_DIR = Path("workbooks")
 
 def build_client() -> tuple[genai.Client, str]:
     """Build a Google Gen AI client backed by Vertex AI."""
-    project = os.environ.get("GOOGLE_CLOUD_PROJECT")
+    project = os.environ.get("GOOGLE_CLOUD_PROJECT", "").strip()
     if not project:
         print("Error: GOOGLE_CLOUD_PROJECT is not set", file=sys.stderr)
         sys.exit(1)
-    location = os.environ.get("GOOGLE_CLOUD_LOCATION") or "us-central1"
-    model = os.environ.get("GEMINI_MODEL") or "gemini-2.0-flash-001"
+    location = (os.environ.get("GOOGLE_CLOUD_LOCATION") or "").strip() or "us-central1"
+    model = (os.environ.get("GEMINI_MODEL") or "").strip() or "gemini-2.0-flash"
+    print(f"Using Vertex AI - project: {project}, location: {location}, model: {model}")
     return genai.Client(vertexai=True, project=project, location=location), model
 
 

--- a/scripts/daily_quiz/score_answers.py
+++ b/scripts/daily_quiz/score_answers.py
@@ -20,17 +20,18 @@ from prompts import SCORE_SYSTEM_PROMPT
 
 JST = timezone(timedelta(hours=9))
 WORKBOOKS_DIR = Path("workbooks")
-DEFAULT_MODEL = "gemini-2.0-flash-001"
+DEFAULT_MODEL = "gemini-2.0-flash"
 
 
 def build_client() -> tuple[genai.Client, str]:
     """Build a Google Gen AI client backed by Vertex AI."""
-    project = os.environ.get("GOOGLE_CLOUD_PROJECT")
+    project = os.environ.get("GOOGLE_CLOUD_PROJECT", "").strip()
     if not project:
         print("Error: GOOGLE_CLOUD_PROJECT is not set", file=sys.stderr)
         sys.exit(1)
-    location = os.environ.get("GOOGLE_CLOUD_LOCATION") or "us-central1"
-    model = os.environ.get("GEMINI_MODEL") or DEFAULT_MODEL
+    location = (os.environ.get("GOOGLE_CLOUD_LOCATION") or "").strip() or "us-central1"
+    model = (os.environ.get("GEMINI_MODEL") or "").strip() or DEFAULT_MODEL
+    print(f"Using Vertex AI - project: {project}, location: {location}, model: {model}")
     return genai.Client(vertexai=True, project=project, location=location), model
 
 


### PR DESCRIPTION
Trim environment variable values and provide reliable fallbacks in daily_quiz scripts. Both generate_quiz.py and score_answers.py now strip GOOGLE_CLOUD_PROJECT, GOOGLE_CLOUD_LOCATION, and GEMINI_MODEL, defaulting to project error exit, location "us-central1", and model "gemini-2.0-flash" (also updated DEFAULT_MODEL in score_answers.py). Added a debug print to show the Vertex AI project/location/model being used. These changes prevent issues from extraneous whitespace and align the default Gemini model name.